### PR TITLE
Feat: 삭제하기 버튼

### DIFF
--- a/src/components/answerCards/AnswerCardList.jsx
+++ b/src/components/answerCards/AnswerCardList.jsx
@@ -1,13 +1,16 @@
 import { Text, TextType } from 'components/text/Text.jsx';
 import * as S from 'components/answerCards/answerCards.style.jsx';
 import AnswerCardItem from 'components/answerCards/AnswerCardItem.jsx';
+import FloatingButton from 'components/floatingButton/FloatingButton.jsx';
 import { postCreateReaction } from 'pages/post/postPage.js';
 import { useState } from 'react';
 import useAsync from 'hooks/useAsync.js';
+import { fetchClient } from 'utils/apiClient';
+import { CONFIRM_MESSAGE, DELETE_USER_MESSAGE } from 'utils/constants.js';
 
 const REACTION_MAX_INT = 2147483647;
 
-const AnswerCardList = ({ questionInfo, subjectOwner }) => {
+const AnswerCardList = ({ questionInfo, subjectOwner, subjectId }) => {
   const { results, count } = questionInfo;
   const [questions, setQuestions] = useState(results);
 
@@ -34,27 +37,44 @@ const AnswerCardList = ({ questionInfo, subjectOwner }) => {
     localStorageReaction[questionId] = true;
     localStorage.setItem(type, JSON.stringify(localStorageReaction));
   };
+
+  const handleDeleteId = async () => {
+    if (window.confirm(CONFIRM_MESSAGE)) {
+      await fetchClient({
+        url: `subjects/${subjectId}/`,
+        method: 'DELETE',
+      });
+      localStorage.removeItem('userId');
+      alert(DELETE_USER_MESSAGE);
+      window.location.replace('/');
+    }
+  };
   return (
-    <S.PostCardList>
-      <S.PostCardListTitleBox>
-        <S.SpeechBubble />
-        <Text
-          $normalType={TextType.Body1Bol}
-          $mobileType={TextType.Body2Bol}
-          text={`${count}개의 질문이 있습니다.`}
-        />
-      </S.PostCardListTitleBox>
-      {questions?.map((question, questionIndex) => (
-        <AnswerCardItem
-          key={question.id}
-          question={question}
-          setQuestions={setQuestions}
-          subjectOwner={subjectOwner}
-          questionIndex={questionIndex}
-          handleReaction={handleReaction}
-        />
-      ))}
-    </S.PostCardList>
+    <>
+      <S.FloatingButtonItem>
+        <FloatingButton type="D" onClick={handleDeleteId} />
+      </S.FloatingButtonItem>
+      <S.PostCardList>
+        <S.PostCardListTitleBox>
+          <S.SpeechBubble />
+          <Text
+            $normalType={TextType.Body1Bol}
+            $mobileType={TextType.Body2Bol}
+            text={`${count}개의 질문이 있습니다.`}
+          />
+        </S.PostCardListTitleBox>
+        {questions?.map((question, questionIndex) => (
+          <AnswerCardItem
+            key={question.id}
+            question={question}
+            setQuestions={setQuestions}
+            subjectOwner={subjectOwner}
+            questionIndex={questionIndex}
+            handleReaction={handleReaction}
+          />
+        ))}
+      </S.PostCardList>
+    </>
   );
 };
 

--- a/src/components/answerCards/answerCards.style.jsx
+++ b/src/components/answerCards/answerCards.style.jsx
@@ -142,3 +142,9 @@ export const EditButtonItem = styled.div`
 export const QnaFormItem = styled.div`
   width: 100%;
 `;
+
+export const FloatingButtonItem = styled.div`
+  display: flex;
+  justify-content: end;
+  margin-bottom: 1rem;
+`;

--- a/src/components/floatingButton/FloatingButton.jsx
+++ b/src/components/floatingButton/FloatingButton.jsx
@@ -5,7 +5,7 @@ const FloatingButton = ({ type, onClick }) => {
   const buttonText = type === 'W' ? '질문 작성하기' : '삭제하기';
 
   return (
-    <S.FloatingButton onClick={onClick}>
+    <S.FloatingButton type={type} onClick={onClick}>
       <Text $normalType={TextType.Body1Bol} text={buttonText} />
     </S.FloatingButton>
   );

--- a/src/components/postCards/QuestionCardList.jsx
+++ b/src/components/postCards/QuestionCardList.jsx
@@ -1,13 +1,14 @@
 import { Text, TextType } from 'components/text/Text.jsx';
 import * as S from 'components/postCards/questionCards.style.jsx';
 import QuestionCardItem from 'components/postCards/QuestionCardItem';
+import FloatingButton from 'components/floatingButton/FloatingButton.jsx';
 import { postCreateReaction } from 'pages/post/postPage.js';
 import { useState } from 'react';
 import useAsync from 'hooks/useAsync.js';
 
 const REACTION_MAX_INT = 2147483647;
 
-const QuestionCardList = ({ questionInfo, subjectOwner }) => {
+const QuestionCardList = ({ questionInfo, subjectOwner, openModal }) => {
   const { results, count } = questionInfo;
   const [questions, setQuestions] = useState(results);
 
@@ -35,26 +36,31 @@ const QuestionCardList = ({ questionInfo, subjectOwner }) => {
     localStorage.setItem(type, JSON.stringify(localStorageReaction));
   };
   return (
-    <S.PostCardList>
-      <S.PostCardListTitleBox>
-        <S.SpeechBubble />
-        <Text
-          $normalType={TextType.Body1Bol}
-          $mobileType={TextType.Body2Bol}
-          text={`${count}개의 질문이 있습니다.`}
-        />
-      </S.PostCardListTitleBox>
-      {questions?.map((question, questionIndex) => (
-        <QuestionCardItem
-          key={question.id}
-          question={question}
-          setQuestions={setQuestions}
-          subjectOwner={subjectOwner}
-          questionIndex={questionIndex}
-          handleReaction={handleReaction}
-        />
-      ))}
-    </S.PostCardList>
+    <>
+      <S.FloatingButtonItem>
+        <FloatingButton type="W" onClick={openModal} />
+      </S.FloatingButtonItem>
+      <S.PostCardList>
+        <S.PostCardListTitleBox>
+          <S.SpeechBubble />
+          <Text
+            $normalType={TextType.Body1Bol}
+            $mobileType={TextType.Body2Bol}
+            text={`${count}개의 질문이 있습니다.`}
+          />
+        </S.PostCardListTitleBox>
+        {questions?.map((question, questionIndex) => (
+          <QuestionCardItem
+            key={question.id}
+            question={question}
+            setQuestions={setQuestions}
+            subjectOwner={subjectOwner}
+            questionIndex={questionIndex}
+            handleReaction={handleReaction}
+          />
+        ))}
+      </S.PostCardList>
+    </>
   );
 };
 

--- a/src/components/postCards/QuestionCards.style.jsx
+++ b/src/components/postCards/QuestionCards.style.jsx
@@ -131,3 +131,9 @@ export const SpeechBubble = styled(MessagesImage)`
   width: 2.4rem;
   height: 2.4rem;
 `;
+
+export const FloatingButtonItem = styled.div`
+  position: fixed;
+  bottom: 2.4rem;
+  right: 2.4rem;
+`;

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -45,7 +45,7 @@ const PostPage = () => {
         method: 'DELETE',
       });
       localStorage.removeItem('userId');
-      alert('계정이 삭제되었습니다.');
+      alert('계정이 삭제되었습니다. 메인페이지로 돌아갑니다.');
       window.location.replace('/');
     }
   };
@@ -78,6 +78,11 @@ const PostPage = () => {
         </S.UserIdText>
       </S.HeaderUserProfile>
       <ShareButtons />
+      {isAnswerPage() && (
+        <S.FloatingButtonItem>
+          <FloatingButton type="D" onClick={handleDeleteId} />
+        </S.FloatingButtonItem>
+      )}
       {isAnswerPage() ? (
         questionInfo?.count ? (
           <S.CardListBox>
@@ -118,15 +123,12 @@ const PostPage = () => {
         </S.FeedCardsBox>
       )}
       <>
-        {isAnswerPage() ? (
-          <S.FloatingButtonItem>
-            <FloatingButton type="D" onClick={handleDeleteId} />
-          </S.FloatingButtonItem>
-        ) : (
+        {!isAnswerPage() && (
           <S.FloatingButtonItem>
             <FloatingButton type="W" onClick={openModal} />
           </S.FloatingButtonItem>
         )}
+
         {!isAnswerPage() && (
           <Modal>
             <QuestionModal onClickClose={closeModal} />

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from 'react';
 import useAsync from 'hooks/useAsync';
 import { getPosts } from 'pages/post/postPage.js';
 import { fetchClient } from 'utils/apiClient';
+import { CONFIRM_MESSAGE, DELETE_USER_MESSAGE } from 'utils/constants.js';
 
 const PostPage = () => {
   const { subjectId } = useParams();
@@ -34,18 +35,13 @@ const PostPage = () => {
   );
 
   const handleDeleteId = async () => {
-    if (
-      window.confirm(
-        `[주의] 계정 삭제는 복구할 수 없으며, 모든 데이터가 영구적으로 제거됩니다.
-        계속하시겠습니까?`,
-      )
-    ) {
+    if (window.confirm(CONFIRM_MESSAGE)) {
       await fetchClient({
         url: `subjects/${subjectId}/`,
         method: 'DELETE',
       });
       localStorage.removeItem('userId');
-      alert('계정이 삭제되었습니다. 메인페이지로 돌아갑니다.');
+      alert(DELETE_USER_MESSAGE);
       window.location.replace('/');
     }
   };

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -4,7 +4,7 @@ import headerImage from 'assets/images/header-background.png';
 import logo from 'assets/images/logo.png';
 import emptyImg from 'assets/images/no-question.png';
 import ShareButtons from 'components/shareButtons/ShareButtons.jsx';
-import FloatingButton from 'components/floatingButton/FloatingButton.jsx';
+
 import QuestionCardList from 'components/postCards/QuestionCardList.jsx';
 import AnswerCardList from 'components/answerCards/AnswerCardList.jsx';
 import QuestionModal from 'components/modal/modalContent/QuestionModal.jsx';
@@ -13,8 +13,6 @@ import { Navigate, useParams, useLocation } from 'react-router-dom';
 import { useCallback, useEffect, useState } from 'react';
 import useAsync from 'hooks/useAsync';
 import { getPosts } from 'pages/post/postPage.js';
-import { fetchClient } from 'utils/apiClient';
-import { CONFIRM_MESSAGE, DELETE_USER_MESSAGE } from 'utils/constants.js';
 
 const PostPage = () => {
   const { subjectId } = useParams();
@@ -33,18 +31,6 @@ const PostPage = () => {
     },
     [getPostsAsync],
   );
-
-  const handleDeleteId = async () => {
-    if (window.confirm(CONFIRM_MESSAGE)) {
-      await fetchClient({
-        url: `subjects/${subjectId}/`,
-        method: 'DELETE',
-      });
-      localStorage.removeItem('userId');
-      alert(DELETE_USER_MESSAGE);
-      window.location.replace('/');
-    }
-  };
 
   const isAnswerPage = () => {
     return location.pathname === `/post/${subjectId}/answer`;
@@ -74,17 +60,13 @@ const PostPage = () => {
         </S.UserIdText>
       </S.HeaderUserProfile>
       <ShareButtons />
-      {isAnswerPage() && (
-        <S.FloatingButtonItem>
-          <FloatingButton type="D" onClick={handleDeleteId} />
-        </S.FloatingButtonItem>
-      )}
       {isAnswerPage() ? (
         questionInfo?.count ? (
           <S.CardListBox>
             <AnswerCardList
               questionInfo={questionInfo}
               subjectOwner={subjectOwner}
+              subjectId={subjectId}
             />
           </S.CardListBox>
         ) : (
@@ -104,6 +86,7 @@ const PostPage = () => {
           <QuestionCardList
             questionInfo={questionInfo}
             subjectOwner={subjectOwner}
+            openModal={openModal}
           />
         </S.CardListBox>
       ) : (
@@ -119,12 +102,6 @@ const PostPage = () => {
         </S.FeedCardsBox>
       )}
       <>
-        {!isAnswerPage() && (
-          <S.FloatingButtonItem>
-            <FloatingButton type="W" onClick={openModal} />
-          </S.FloatingButtonItem>
-        )}
-
         {!isAnswerPage() && (
           <Modal>
             <QuestionModal onClickClose={closeModal} />

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -13,6 +13,7 @@ import { Navigate, useParams, useLocation } from 'react-router-dom';
 import { useCallback, useEffect, useState } from 'react';
 import useAsync from 'hooks/useAsync';
 import { getPosts } from 'pages/post/postPage.js';
+import { fetchClient } from 'utils/apiClient';
 
 const PostPage = () => {
   const { subjectId } = useParams();
@@ -31,6 +32,23 @@ const PostPage = () => {
     },
     [getPostsAsync],
   );
+
+  const handleDeleteId = async () => {
+    if (
+      window.confirm(
+        `[주의] 계정 삭제는 복구할 수 없으며, 모든 데이터가 영구적으로 제거됩니다.
+        계속하시겠습니까?`,
+      )
+    ) {
+      await fetchClient({
+        url: `subjects/${subjectId}/`,
+        method: 'DELETE',
+      });
+      localStorage.removeItem('userId');
+      alert('계정이 삭제되었습니다.');
+      window.location.replace('/');
+    }
+  };
 
   const isAnswerPage = () => {
     return location.pathname === `/post/${subjectId}/answer`;
@@ -100,12 +118,20 @@ const PostPage = () => {
         </S.FeedCardsBox>
       )}
       <>
-        <S.FloatingButtonItem>
-          <FloatingButton type="W" onClick={openModal} />
-        </S.FloatingButtonItem>
-        <Modal>
-          <QuestionModal onClickClose={closeModal} />
-        </Modal>
+        {isAnswerPage() ? (
+          <S.FloatingButtonItem>
+            <FloatingButton type="D" onClick={handleDeleteId} />
+          </S.FloatingButtonItem>
+        ) : (
+          <S.FloatingButtonItem>
+            <FloatingButton type="W" onClick={openModal} />
+          </S.FloatingButtonItem>
+        )}
+        {!isAnswerPage() && (
+          <Modal>
+            <QuestionModal onClickClose={closeModal} />
+          </Modal>
+        )}
       </>
     </S.PostPageContainer>
   );

--- a/src/pages/post/postPage.style.jsx
+++ b/src/pages/post/postPage.style.jsx
@@ -81,9 +81,3 @@ export const MessageBox = styled.div`
   gap: 0.8rem;
   color: ${COLORS.BROWN40};
 `;
-
-export const FloatingButtonItem = styled.div`
-  position: fixed;
-  bottom: 2.4rem;
-  right: 2.4rem;
-`;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -11,3 +11,9 @@ export const Z_INDEX = {
 };
 
 export const BODY_DEFAULT_OVERFLOW = '';
+
+export const CONFIRM_MESSAGE = `[주의] 계정 삭제는 복구할 수 없으며, 모든 데이터가 영구적으로 제거됩니다.
+계속하시겠습니까?`;
+
+export const DELETE_USER_MESSAGE =
+  '계정이 삭제되었습니다. 메인페이지로 돌아갑니다.';


### PR DESCRIPTION

<img width="525" alt="스크린샷 2023-11-13 오후 8 59 16" src="https://github.com/toy-stories/open-mind/assets/120437902/5e521ba7-c6da-4570-94e1-b6bbddec8aa4">

<img width="491" alt="스크린샷 2023-11-13 오후 8 59 39" src="https://github.com/toy-stories/open-mind/assets/120437902/1c08bb02-ae55-4f8c-9a9b-06f13ca6647f">

- [x]  answer 페이지에서  질문작성하기 버튼이 삭제하기 버튼으로 바뀌도록 수정
- [x] 삭제하기 버튼 클릭시 계정 삭제 confirm창 띄우기 -> 확인 누르면 계정 삭제 후 메인페이지로 이동
- [ ] 삭제하기 버튼 위치 변경
- [ ] confirm창 라이브러리 적용(할까말까고민중입니다.)

