### PR TITLE
Feat: 포스트페이지 반응형 스타일 적용

### DIFF
--- a/src/components/answerCards/answerCards.style.jsx
+++ b/src/components/answerCards/answerCards.style.jsx
@@ -35,7 +35,6 @@ export const TitleBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  width: 56rem;
 `;
 
 export const UpdateTimeBox = styled.div`
@@ -46,7 +45,6 @@ export const ContentBox = styled.div`
   display: flex;
   gap: 1.2rem;
   align-self: stretch;
-  width: 56rem;
 `;
 
 export const ContentUserInfoBox = styled.div`
@@ -111,6 +109,7 @@ export const RefuseAnswerBox = styled.div`
 `;
 
 export const PostCardList = styled.ul`
+  padding: 13.6rem;
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/src/components/answerCards/answerCards.style.jsx
+++ b/src/components/answerCards/answerCards.style.jsx
@@ -109,6 +109,7 @@ export const RefuseAnswerBox = styled.div`
 `;
 
 export const PostCardList = styled.ul`
+  flex: 0 1 71.6rem;
   padding: 13.6rem;
   display: flex;
   flex-direction: column;

--- a/src/components/floatingButton/FloatingButton.jsx
+++ b/src/components/floatingButton/FloatingButton.jsx
@@ -2,10 +2,10 @@ import * as S from 'components/floatingButton/floatingButton.style.jsx';
 import { Text, TextType } from 'components/text/Text.jsx';
 
 const FloatingButton = ({ type, onClick }) => {
-  const buttonText = type === 'W' ? '질문 작성하기' : '삭제하기';
+  const buttonText = type === 'W' ? '질문 작성' : '삭제하기';
 
   return (
-    <S.FloatingButton onClick={onClick}>
+    <S.FloatingButton $isQuestion={type === 'W'} onClick={onClick}>
       <Text $normalType={TextType.Body1Bol} text={buttonText} />
     </S.FloatingButton>
   );

--- a/src/components/floatingButton/floatingButton.style.jsx
+++ b/src/components/floatingButton/floatingButton.style.jsx
@@ -1,5 +1,6 @@
 import { styled } from 'styled-components';
 import COLORS from 'utils/colors.js';
+import { RESPONSIBLE_SIZE } from 'utils/constants';
 
 export const FloatingButton = styled.button`
   display: flex;
@@ -11,4 +12,12 @@ export const FloatingButton = styled.button`
   background-color: ${COLORS.BROWN40};
   border-radius: 200px;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  & p::after {
+    ${({ $isQuestion }) => ($isQuestion ? "content: '하기';" : "content: '';")}
+  }
+  @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
+    & p::after {
+      content: '';
+    }
+  }
 `;

--- a/src/components/postCards/QuestionCardItem.jsx
+++ b/src/components/postCards/QuestionCardItem.jsx
@@ -1,5 +1,5 @@
 import { Text, TextType } from 'components/text/Text.jsx';
-import * as S from 'components/postCards/questionCards.style.jsx';
+import * as S from 'components/postCards/QuestionCards.style.jsx';
 import { useEffect, useState } from 'react';
 import defaultUserIconImage from 'assets/images/default-profile-image.png';
 import dayjs from 'dayjs';

--- a/src/components/postCards/QuestionCardList.jsx
+++ b/src/components/postCards/QuestionCardList.jsx
@@ -1,5 +1,5 @@
 import { Text, TextType } from 'components/text/Text.jsx';
-import * as S from 'components/postCards/questionCards.style.jsx';
+import * as S from 'components/postCards/QuestionCards.style.jsx';
 import QuestionCardItem from 'components/postCards/QuestionCardItem';
 import { postCreateReaction } from 'pages/post/postPage.js';
 import { useState } from 'react';

--- a/src/components/postCards/QuestionCards.style.jsx
+++ b/src/components/postCards/QuestionCards.style.jsx
@@ -35,7 +35,6 @@ export const TitleBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  width: 56rem;
 `;
 
 export const UpdateTimeBox = styled.div`
@@ -46,7 +45,6 @@ export const ContentBox = styled.div`
   display: flex;
   gap: 1.2rem;
   align-self: stretch;
-  width: 56rem;
 `;
 
 export const ContentUserInfoBox = styled.div`
@@ -117,6 +115,7 @@ export const PostCardList = styled.ul`
   background: ${COLORS.BROWN10};
   border: 1px solid ${COLORS.BROWN30};
   border-radius: 1.6rem;
+  max-width: 71.6rem;
 `;
 
 export const PostCardListTitleBox = styled.div`

--- a/src/components/postCards/QuestionCards.style.jsx
+++ b/src/components/postCards/QuestionCards.style.jsx
@@ -110,12 +110,13 @@ export const RefuseAnswerBox = styled.div`
 export const PostCardList = styled.ul`
   display: flex;
   flex-direction: column;
+  flex: 0 1 71.6rem;
   gap: 2rem;
   padding: 1.6rem;
   background: ${COLORS.BROWN10};
   border: 1px solid ${COLORS.BROWN30};
   border-radius: 1.6rem;
-  max-width: 71.6rem;
+  height: 100%;
 `;
 
 export const PostCardListTitleBox = styled.div`

--- a/src/components/shareButtons/shareButtons.style.jsx
+++ b/src/components/shareButtons/shareButtons.style.jsx
@@ -4,8 +4,6 @@ export const ShareButtons = styled.div`
   display: flex;
   flex-direction: row;
   gap: 1.2rem;
-  position: absolute;
-  top: 32.9rem;
 `;
 
 export const ShareButton = styled.img`

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -44,22 +44,24 @@ const PostPage = () => {
   if (hasError) return <Navigate to="/" />;
   return (
     <S.PostPageContainer>
-      <S.HeaderImage src={headerImage} alt="헤더 배경 이미지" />
-      <S.Logo src={logo} alt="오픈마인드 로고" />
-      <S.HeaderUserProfile>
-        <S.ProfileImage
-          src={subjectOwner?.imageSource}
-          alt="유저 프로필 이미지"
-        />
-        <S.UserIdText>
-          <Text
-            $normalType={TextType.H2}
-            $mobileType={TextType.H3}
-            text={subjectOwner?.name}
+      <S.HeaderContainer>
+        <S.Header>
+          <S.Logo src={logo} alt="오픈마인드 로고" />
+          <S.ProfileImage
+            src={subjectOwner?.imageSource}
+            alt="유저 프로필 이미지"
           />
-        </S.UserIdText>
-      </S.HeaderUserProfile>
-      <ShareButtons />
+          <S.UserIdText>
+            <Text
+              $normalType={TextType.H2}
+              $mobileType={TextType.H3}
+              text={subjectOwner?.name}
+            />
+          </S.UserIdText>
+          <ShareButtons />
+        </S.Header>
+      </S.HeaderContainer>
+
       {isAnswerPage() ? (
         questionInfo?.count ? (
           <S.CardListBox>
@@ -100,13 +102,13 @@ const PostPage = () => {
         </S.FeedCardsBox>
       )}
       <>
-        <S.FloatingButtonItem>
-          <FloatingButton type="W" onClick={openModal} />
-        </S.FloatingButtonItem>
         <Modal>
           <QuestionModal onClickClose={closeModal} />
         </Modal>
       </>
+      <S.FloatingButtonItem>
+        <FloatingButton type="W" onClick={openModal} />
+      </S.FloatingButtonItem>
     </S.PostPageContainer>
   );
 };

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -1,6 +1,5 @@
 import * as S from 'pages/post/postPage.style.jsx';
 import { Text, TextType } from 'components/text/Text.jsx';
-import headerImage from 'assets/images/header-background.png';
 import logo from 'assets/images/logo.png';
 import emptyImg from 'assets/images/no-question.png';
 import ShareButtons from 'components/shareButtons/ShareButtons.jsx';
@@ -9,7 +8,7 @@ import QuestionCardList from 'components/postCards/QuestionCardList.jsx';
 import AnswerCardList from 'components/answerCards/AnswerCardList.jsx';
 import QuestionModal from 'components/modal/modalContent/QuestionModal.jsx';
 import useModal from 'hooks/useModal.js';
-import { Navigate, useParams, useLocation } from 'react-router-dom';
+import { Navigate, useParams, useLocation, Link } from 'react-router-dom';
 import { useCallback, useEffect, useState } from 'react';
 import useAsync from 'hooks/useAsync';
 import { getPosts } from 'pages/post/postPage.js';
@@ -45,23 +44,20 @@ const PostPage = () => {
   return (
     <S.PostPageContainer>
       <S.HeaderContainer>
-        <S.Header>
+        <Link to="/">
           <S.Logo src={logo} alt="오픈마인드 로고" />
-          <S.ProfileImage
-            src={subjectOwner?.imageSource}
-            alt="유저 프로필 이미지"
-          />
-          <S.UserIdText>
-            <Text
-              $normalType={TextType.H2}
-              $mobileType={TextType.H3}
-              text={subjectOwner?.name}
-            />
-          </S.UserIdText>
-          <ShareButtons />
-        </S.Header>
+        </Link>
+        <S.ProfileImage
+          src={subjectOwner?.imageSource}
+          alt="유저 프로필 이미지"
+        />
+        <Text
+          $normalType={TextType.H2}
+          $mobileType={TextType.H3}
+          text={subjectOwner?.name}
+        />
+        <ShareButtons />
       </S.HeaderContainer>
-
       {isAnswerPage() ? (
         questionInfo?.count ? (
           <S.CardListBox>
@@ -71,6 +67,28 @@ const PostPage = () => {
             />
           </S.CardListBox>
         ) : (
+          <S.FeedCardsContainer>
+            <S.FeedCardsBox>
+              <S.MessageBox>
+                <S.MessageIcon alt="메세지 아이콘" />
+                <Text
+                  $normalType={TextType.Body1Bol}
+                  text="아직 질문이 없습니다."
+                />
+              </S.MessageBox>
+              <S.EmptyImage src={emptyImg} alt="빈 박스 이미지" />
+            </S.FeedCardsBox>
+          </S.FeedCardsContainer>
+        )
+      ) : questionInfo?.count ? (
+        <S.CardListBox>
+          <QuestionCardList
+            questionInfo={questionInfo}
+            subjectOwner={subjectOwner}
+          />
+        </S.CardListBox>
+      ) : (
+        <S.FeedCardsContainer>
           <S.FeedCardsBox>
             <S.MessageBox>
               <S.MessageIcon alt="메세지 아이콘" />
@@ -81,34 +99,16 @@ const PostPage = () => {
             </S.MessageBox>
             <S.EmptyImage src={emptyImg} alt="빈 박스 이미지" />
           </S.FeedCardsBox>
-        )
-      ) : questionInfo?.count ? (
-        <S.CardListBox>
-          <QuestionCardList
-            questionInfo={questionInfo}
-            subjectOwner={subjectOwner}
-          />
-        </S.CardListBox>
-      ) : (
-        <S.FeedCardsBox>
-          <S.MessageBox>
-            <S.MessageIcon alt="메세지 아이콘" />
-            <Text
-              $normalType={TextType.Body1Bol}
-              text="아직 질문이 없습니다."
-            />
-          </S.MessageBox>
-          <S.EmptyImage src={emptyImg} alt="빈 박스 이미지" />
-        </S.FeedCardsBox>
+        </S.FeedCardsContainer>
       )}
       <>
         <Modal>
           <QuestionModal onClickClose={closeModal} />
         </Modal>
+        <S.FloatingButtonItem>
+          <FloatingButton type="W" onClick={openModal} />
+        </S.FloatingButtonItem>
       </>
-      <S.FloatingButtonItem>
-        <FloatingButton type="W" onClick={openModal} />
-      </S.FloatingButtonItem>
     </S.PostPageContainer>
   );
 };

--- a/src/pages/post/postPage.style.jsx
+++ b/src/pages/post/postPage.style.jsx
@@ -33,7 +33,6 @@ export const HeaderContainer = styled.header`
   gap: 1.2rem;
   @media only screen and (max-width: 1820px) {
     background-size: contain;
-    padding: 4rem;
   }
   @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
     padding: 4rem;

--- a/src/pages/post/postPage.style.jsx
+++ b/src/pages/post/postPage.style.jsx
@@ -10,6 +10,7 @@ export const PostPageContainer = styled.div`
   justify-content: center;
   align-items: center;
   background-color: ${COLORS.GRAY20};
+  min-height: 100vh;
 `;
 
 export const HeaderImage = styled.img`
@@ -20,10 +21,20 @@ export const HeaderImage = styled.img`
 
 export const HeaderContainer = styled.header`
   background-image: url(${headerImage});
-  background-size: contain;
+  background-size: cover;
   background-repeat: no-repeat;
+  background-position: center center;
   width: 100%;
   padding: 5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.2rem;
+  @media only screen and (max-width: 1820px) {
+    background-size: contain;
+    padding: 4rem;
+  }
   @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
     padding: 4rem;
   }
@@ -33,13 +44,6 @@ export const Logo = styled.img`
   width: 17rem;
 `;
 
-export const Header = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 1.2rem;
-`;
 export const ProfileImage = styled.img`
   width: 13.6rem;
   height: 13.6rem;
@@ -50,31 +54,38 @@ export const ProfileImage = styled.img`
   }
 `;
 
-export const UserIdText = styled.div``;
-
 export const CardListBox = styled.div`
+  flex: 1;
   position: relative;
   width: 100%;
   display: flex;
   justify-content: center;
-  padding: 2.4rem;
+  padding: 1.4rem 2.4rem 13.6rem;
+  @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
+    padding-bottom: 12.6rem;
+  }
+`;
+
+export const FeedCardsContainer = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 3.2rem;
 `;
 
 export const FeedCardsBox = styled.div`
   display: flex;
   flex-direction: column;
-  width: 71.6rem;
-  height: 33rem;
+  flex: 0 1 71.6rem;
+  height: 100%;
   padding: 1.6rem 2.4rem;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
   border-radius: 16px;
   border: 1px solid ${COLORS.BROWN20};
   background: ${COLORS.BROWN10};
   position: relative;
-  margin-top: 42.3rem;
-  margin-bottom: 13.6rem;
 `;
 
 export const MessageIcon = styled(MessageIconSvg)`

--- a/src/pages/post/postPage.style.jsx
+++ b/src/pages/post/postPage.style.jsx
@@ -1,12 +1,15 @@
 import { styled } from 'styled-components';
 import COLORS from 'utils/colors.js';
 import { ReactComponent as MessageIconSvg } from 'assets/icons/Messages.svg';
+import { RESPONSIBLE_SIZE } from 'utils/constants';
+import headerImage from 'assets/images/header-background.png';
 
 export const PostPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  background-color: ${COLORS.GRAY20};
 `;
 
 export const HeaderImage = styled.img`
@@ -15,35 +18,46 @@ export const HeaderImage = styled.img`
   top: 0;
 `;
 
-export const Logo = styled.img`
-  width: 17rem;
-  position: absolute;
-  top: 5rem;
+export const HeaderContainer = styled.header`
+  background-image: url(${headerImage});
+  background-size: contain;
+  background-repeat: no-repeat;
+  width: 100%;
+  padding: 5rem;
+  @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
+    padding: 4rem;
+  }
 `;
 
-export const HeaderUserProfile = styled.div`
+export const Logo = styled.img`
+  width: 17rem;
+`;
+
+export const Header = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 1.2rem;
 `;
 export const ProfileImage = styled.img`
   width: 13.6rem;
   height: 13.6rem;
-  position: absolute;
-  top: 12.9rem;
   border-radius: 50%;
+  @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
+    width: 10.4rem;
+    height: 10.4rem;
+  }
 `;
 
-export const UserIdText = styled.div`
-  position: absolute;
-  top: 27.7rem;
-`;
+export const UserIdText = styled.div``;
 
 export const CardListBox = styled.div`
   position: relative;
-  margin-top: 42.3rem;
-  margin-bottom: 13.6rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 2.4rem;
 `;
 
 export const FeedCardsBox = styled.div`


### PR DESCRIPTION
- [x] 질문작성 버튼 텍스트 반응형
- [x] 질문없음 페이지 반응형

헤더부분의 백그라운드 이미지가 1800px 이상되면 짤리는 현상이 있어서 


```jsx
export const HeaderContainer = styled.header`
  background-image: url(${headerImage});
  background-size: cover;
  background-repeat: no-repeat;
  background-position: center center;
  width: 100%;
  padding: 5rem;
  @media only screen and (max-width: 1820px) {
    background-size: contain;
  }
  @media only screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
    padding: 4rem;
  }
`;
```
현재 이렇게 적용해둔 상태인데

한번밖에 쓰이지 않을 것 같아서
constants.js에 pc화면 사이즈를 추가하는게 좋을지 아니면 그냥 하드코딩하는게 좋을지 모르겠습니당..
