### PR TITLE
Feat: 디테일 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7750,11 +7750,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -15224,11 +15219,6 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
-    },
-    "node_modules/promise-polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-      "integrity": "sha512-g0LWaH0gFsxovsU7R5LrrhHhWAWiHRnh1GPrhXnPgYsDkIqjRYUYSZEsej/wtleDrz5xVSIDbeKfidztp2XHFQ=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/src/components/answerCards/AnswerCardItem.jsx
+++ b/src/components/answerCards/AnswerCardItem.jsx
@@ -300,7 +300,7 @@ const AnswerCardItem = ({
               }`}
             />
           </S.DislikeButton>
-          {question?.answer && !isEditActive && (
+          {question?.answer?.isRejected === false && !isEditActive && (
             <S.EditButtonItem onClick={handleEditButtonClick}>
               <EditButton isEditActive={isEditActive} />
             </S.EditButtonItem>

--- a/src/components/linkButton/linkButton.style.jsx
+++ b/src/components/linkButton/linkButton.style.jsx
@@ -26,6 +26,7 @@ export const StyledLinkButton = styled.button`
   @media screen and (max-width: ${RESPONSIBLE_SIZE.mobile}) {
     padding: 0.8rem 1.2rem;
     gap: 0.4rem;
+    white-space: nowrap;
   }
 `;
 

--- a/src/components/toast/toast.style.jsx
+++ b/src/components/toast/toast.style.jsx
@@ -28,7 +28,7 @@ export const ToastBox = styled.div`
   color: ${COLORS.WHITE};
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   position: fixed;
-  top: 50%;
+  bottom: 10%;
   left: 50%;
   transform: translateX(-50%);
   z-index: 1;

--- a/src/pages/post/postPage.style.jsx
+++ b/src/pages/post/postPage.style.jsx
@@ -84,9 +84,10 @@ export const FeedCardsContainer = styled.div`
 export const FeedCardsBox = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 33rem;
   padding: 1.6rem 2.4rem;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   border-radius: 16px;
   border: 1px solid ${COLORS.BROWN20};
@@ -111,4 +112,6 @@ export const MessageBox = styled.div`
   flex-direction: row;
   gap: 0.8rem;
   color: ${COLORS.BROWN40};
+  position: absolute;
+  top: 1.6rem;
 `;


### PR DESCRIPTION

<img width="1399" alt="스크린샷 2023-11-15 오전 10 45 56" src="https://github.com/toy-stories/open-mind/assets/120437902/96678f4e-33a9-4ac5-8728-9536faaa04f8">

- [x]  토스트 위치 변경(하단) : 기존거 풀 땡겨왔더니 위치가 애매하게 바뀌어서 그냥 시안과 비슷하게 bottom 10%로 고정했습니다.
<img width="1435" alt="스크린샷 2023-11-15 오전 10 46 48" src="https://github.com/toy-stories/open-mind/assets/120437902/c762a787-02ff-41a2-9186-c2a4d8111171">

- [x]  Feedcard 사이즈 변경: 시안보다 사이즈가 작아서 키웠습니다.
<img width="410" alt="스크린샷 2023-11-15 오전 10 47 47" src="https://github.com/toy-stories/open-mind/assets/120437902/6ff76a66-c623-4036-910f-0b16e41d3bf7">

- [x] LinkButton 반응형: 모바일에서 글자가 줄바꿈되어서 nowrap속성 추가했습니다.
<img width="359" alt="스크린샷 2023-11-15 오전 10 48 22" src="https://github.com/toy-stories/open-mind/assets/120437902/e6a1a6aa-7716-49e0-b195-92a9776d5b7e">

- [x] 거절된 답변에 수정하기 버튼 안보이게 로직 수정
