### PR TITLE
Refactor: deleteUser 모듈추가, 삭제하기 버튼 질문없을 때도 뜨게 수정

### DIFF
--- a/src/components/answerCards/AnswerCardList.jsx
+++ b/src/components/answerCards/AnswerCardList.jsx
@@ -5,8 +5,7 @@ import FloatingButton from 'components/floatingButton/FloatingButton.jsx';
 import { postCreateReaction } from 'pages/post/postPage.js';
 import useAsync from 'hooks/useAsync.js';
 import LoadingSpinner from 'components/tempLoading/TempLoading';
-import { fetchClient } from 'utils/apiClient';
-import Swal from 'sweetalert2';
+import { handleDeleteUser } from 'utils/deleteUser';
 
 const REACTION_MAX_INT = 2147483647;
 
@@ -40,43 +39,13 @@ const AnswerCardList = ({
     localStorage.setItem(type, JSON.stringify(localStorageReaction));
   };
 
-  const handleDeleteId = async () => {
-    Swal.fire({
-      title:
-        '[주의] 계정 삭제는 복구할 수 없으며, 모든 데이터가 영구적으로 제거됩니다.',
-      text: '계속하시겠습니까?',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#3085d6',
-      cancelButtonColor: '#d33',
-      confirmButtonText: '계정삭제',
-      cancelButtonText: '취소',
-    }).then((result) => {
-      if (result.isConfirmed) {
-        fetchClient({
-          url: `subjects/${subjectOwner.id}/`,
-          method: 'DELETE',
-        }).then((result) => {
-          localStorage.removeItem('userId');
-          Swal.fire({
-            title: '계정삭제완료',
-            text: '계정이 삭제되었습니다. 메인페이지로 돌아갑니다.',
-            icon: 'success',
-            confirmButtonColor: '#3085d6',
-            confirmButtonText: '확인',
-          }).then((result) => {
-            if (result.isConfirmed) {
-              window.location.replace('/');
-            }
-          });
-        });
-      }
-    });
+  const handleDeleteClick = () => {
+    handleDeleteUser(subjectOwner);
   };
 
   return (
     <>
-      <FloatingButton type="A" onClick={handleDeleteId} />
+      <FloatingButton type="A" onClick={handleDeleteClick} />
       <S.PostCardList>
         <S.PostCardListTitleBox>
           <S.SpeechBubble />

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -5,7 +5,7 @@ import emptyImg from 'assets/images/no-question.png';
 import ShareButtons from 'components/shareButtons/ShareButtons.jsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import AnswerCardList from 'components/answerCards/AnswerCardList';
-
+import { handleDeleteUser } from 'utils/deleteUser';
 import QuestionCardList from 'components/postCards/QuestionCardList.jsx';
 import QuestionModal from 'components/modal/modalContent/QuestionModal.jsx';
 import useModal from 'hooks/useModal.js';
@@ -79,6 +79,10 @@ const PostPage = () => {
     return location.pathname === `/post/${subjectId}/answer`;
   };
 
+  const handleDeleteClick = () => {
+    handleDeleteUser(subjectOwner);
+  };
+
   useEffect(() => {
     window.scrollTo(0, 0);
     handleLoad(subjectId);
@@ -116,16 +120,19 @@ const PostPage = () => {
               subjectOwner={subjectOwner}
             />
           ) : (
-            <S.FeedCardsBox>
-              <S.MessageBox>
-                <S.MessageIcon alt="메세지 아이콘" />
-                <Text
-                  $normalType={TextType.Body1Bol}
-                  text="아직 질문이 없습니다."
-                />
-              </S.MessageBox>
-              <S.EmptyImage src={emptyImg} alt="빈 박스 이미지" />
-            </S.FeedCardsBox>
+            <>
+              <FloatingButton type="A" onClick={handleDeleteClick} />
+              <S.FeedCardsBox>
+                <S.MessageBox>
+                  <S.MessageIcon alt="메세지 아이콘" />
+                  <Text
+                    $normalType={TextType.Body1Bol}
+                    text="아직 질문이 없습니다."
+                  />
+                </S.MessageBox>
+                <S.EmptyImage src={emptyImg} alt="빈 박스 이미지" />
+              </S.FeedCardsBox>
+            </>
           )
         ) : questionInfo?.count ? (
           <QuestionCardList

--- a/src/utils/deleteUser.js
+++ b/src/utils/deleteUser.js
@@ -1,0 +1,36 @@
+import { fetchClient } from 'utils/apiClient';
+import Swal from 'sweetalert2';
+
+export const handleDeleteUser = async (subjectOwner) => {
+  Swal.fire({
+    title:
+      '[주의] 계정 삭제는 복구할 수 없으며, 모든 데이터가 영구적으로 제거됩니다.',
+    text: '계속하시겠습니까?',
+    icon: 'warning',
+    showCancelButton: true,
+    confirmButtonColor: '#3085d6',
+    cancelButtonColor: '#d33',
+    confirmButtonText: '계정삭제',
+    cancelButtonText: '취소',
+  }).then((result) => {
+    if (result.isConfirmed) {
+      fetchClient({
+        url: `subjects/${subjectOwner.id}/`,
+        method: 'DELETE',
+      }).then((result) => {
+        localStorage.removeItem('userId');
+        Swal.fire({
+          title: '계정삭제완료',
+          text: '계정이 삭제되었습니다. 메인페이지로 돌아갑니다.',
+          icon: 'success',
+          confirmButtonColor: '#3085d6',
+          confirmButtonText: '확인',
+        }).then((result) => {
+          if (result.isConfirmed) {
+            window.location.replace('/');
+          }
+        });
+      });
+    }
+  });
+};


### PR DESCRIPTION
<img width="813" alt="스크린샷 2023-11-15 오전 11 37 38" src="https://github.com/toy-stories/open-mind/assets/120437902/f00578a1-f1e7-4fab-bc34-37a45d07b2a9">

handler함수를 모듈화하여, FeedCard 렌더링 시에도 삭제하기 버튼이 보이고 작동하도록 수정하였습니다.